### PR TITLE
Changed git:// to https://

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 Quick little recipes app done for a Pluralsight Play-by-Play. Uses Falcor, Webpack, Babel, and React.
 
-To get it running, just `git clone git@github.com:btholt/pluralsight.git`, `npm install`, and open `index.html` in your browser.
+To get it running, just `git clone https://github.com/btholt/pluralsight.git`, `npm install`, and open `index.html` in your browser.


### PR DESCRIPTION
Using git:/ requires a public/private key. using https is easier.
